### PR TITLE
Changed the function name to start with lowercase

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,5 +6,5 @@ import FlutterMacOS
 import Foundation
 
 
-func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+func registerGeneratedPlugins(registry: FlutterPluginRegistry) {
 }


### PR DESCRIPTION
Fixed: Function name should start with a lowercase character: 'RegisterGeneratedPlugins(registry:)'
Close #20