### PR TITLE
fix: prefix and leading zeros

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,7 +69,10 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
         _num1 = 0;
         _num2 = 0;
         _operator = '';
-      } else {
+      } else if (!(buttonText[0] == '0' && _currentNumber[0] == '0')){
+        if (_currentNumber == '0') {
+          _currentNumber = '';
+        }
         _currentNumber += buttonText;
       }
 


### PR DESCRIPTION
Fixes #3 

I added an else if for when the button press is a number and not an operator/clear.

This if statement checks that the user is **NOT** inputting a 0 or 00 **AND** the currently displayed text/number is **NOT** a 0.
```dart
!(buttonText[0] == '0' && _currentNumber[0] == '0')
```
Secondly I added an if statement before appending the newly added number.

This just makes sure that if there is a single zero being displayed, that it gets removed before appending the next number. Otherwise everything continues normally.
```dart
if (_currentNumber == '0') {
    _currentNumber = '';
}
```