### PR TITLE
Fixes #46 Arithmetic Operator not changing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,12 +63,11 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
           _operator = '';
           break;
         case '+' || '-' || 'x' || '/':
-          // Checks if _num1 exists
-          if (_num1 != 0) {
-            // Calculates _num1 with input and puts that value in _num1
-            _num2 = double.parse(_currentNumber);
-            _num1 = performMath(_num1, _num2, _operator);
-            // Resets values allowing user to continue inputting numbers
+          if (_operator != '' && _currentNumber == '') { _operator = buttonText; break; }   // If the operator is already set and there is no second number, change the operator.                     
+          if (_num1 != 0) {                                                                 // Checks if _num1 exists
+            _num1 = performMath(_num1, double.parse(_currentNumber), _operator);            // Calculates _num1 with input and puts that value back in _num1
+            
+            // Resets values allowing user to continue inputting new operations
             _num2 = 0;
             _operator = buttonText;
             _currentNumber = '';
@@ -86,7 +85,7 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
         case '=':
           // Stops users from pressing equals without any input
           if (_num1 == 0 || _operator == '') { break; }
-          // Stops users from pressing equals with entering a last number
+          // Stops users from pressing equals without entering a second number
           if (_currentNumber == '') {
             _currentNumber = _num1.toString();
             _num1 = 0;


### PR DESCRIPTION
### Fixes #46 

The following line of code check if an operator has been previously set and if there is no secondary number already typed. If so, we will set _operator to the last typed operator and break out of the case allowing the user to continue typing either a second number or a different operator. 

```dart
case '+' || '-' || 'x' || '/':
    // If the operator is already set and there is no second number, change the operator
    if (_operator != '' && _currentNumber == '') { _operator = buttonText; break; }
```

It is done this way to confirm that the user meant to switch operators and didn't accidentally add an extra operator after an arithmetic equation.

```
If the user enters: 10, +, -, 5
Program sees: 10 - 5
Display: 5
-------------------------------
If the user enters: 10, -, 5, x
Program sees: 10 - 5
Display: 5
```

### Extra additions and fixes
- Improved/fixed previous comments